### PR TITLE
Support Session Fixation

### DIFF
--- a/lib/Plack/Middleware/Session.pm
+++ b/lib/Plack/Middleware/Session.pm
@@ -75,6 +75,10 @@ sub commit {
 
     if ($options->{expire}) {
         $self->store->remove($options->{id});
+    } elsif ($options->{change_id}) {
+        $self->store->remove($options->{id});
+        $options->{id} = $self->generate_id($env);
+        $self->store->store($options->{id}, $session);
     } else {
         $self->store->store($options->{id}, $session);
     }


### PR DESCRIPTION
Catalyst::Plugin::Session change_session_id method support.

you should call $req->env->{'psgix.session.options'}->{'change_id'}++ in your login controller like this:
# login controller.

if ($self->authenticate( { username => $user, password => $pass } )) {
    # login OK
    $req->env->{'psgix.session.options'}->{'change_id'}++;
    ...
} else {
    # login FAILED
    ...
}

SEE ALSO Catalyst::Plugin::Session
