### PR TITLE
Fixes a POD link in Plack::Session::State::Cookie

### DIFF
--- a/lib/Plack/Session/State/Cookie.pm
+++ b/lib/Plack/Session/State/Cookie.pm
@@ -104,7 +104,7 @@ L<Plack::Middleware::Session>.
 
 The C<%params> can include I<path>, I<domain>, I<expires>, I<secure>,
 and I<httponly> options, as well as all the options accepted by
-L<Plack::Session::Store>.
+L<Plack::Session::State>.
 
 =item B<path>
 


### PR DESCRIPTION
Fixes the reference to the parent class in the documentation for the new method.
