### PR TITLE
use Digest::SHA instead of Digest::SHA1

### DIFF
--- a/META.json
+++ b/META.json
@@ -38,7 +38,7 @@
          "requires" : {
             "Cookie::Baker" : "0",
             "Digest::HMAC_SHA1" : "1.03",
-            "Digest::SHA1" : "0",
+            "Digest::SHA" : "0",
             "Plack" : "0.9910"
          }
       },

--- a/cpanfile
+++ b/cpanfile
@@ -2,7 +2,7 @@ requires 'Plack'            => '0.9910';
 requires 'Cookie::Baker'    => '0';
 
 # for session ID gen
-requires 'Digest::SHA1'      => '0';
+requires 'Digest::SHA'      => '0';
 requires 'Digest::HMAC_SHA1' => '1.03';
 
 # things the tests need

--- a/lib/Plack/Session/State.pm
+++ b/lib/Plack/Session/State.pm
@@ -5,7 +5,7 @@ use warnings;
 our $VERSION   = '0.21';
 our $AUTHORITY = 'cpan:STEVAN';
 
-use Digest::SHA1 ();
+use Digest::SHA ();
 
 use Plack::Request;
 use Plack::Util::Accessor qw[
@@ -19,7 +19,7 @@ sub new {
 
     $params{'session_key'}   ||= 'plack_session';
     $params{'sid_generator'} ||= sub {
-        Digest::SHA1::sha1_hex(rand() . $$ . {} . time)
+        Digest::SHA::sha1_hex(rand() . $$ . {} . time)
     };
     $params{'sid_validator'} ||= qr/\A[0-9a-f]{40}\Z/;
 


### PR DESCRIPTION
Digest::SHA is in core since Perl v5.9.3

(according changes to META.yml/json and cpanfile not included, blame the github web interface...)
