### PR TITLE
add samesite option to State::Cookie. Fixes #40

### DIFF
--- a/lib/Plack/Session/State/Cookie.pm
+++ b/lib/Plack/Session/State/Cookie.pm
@@ -15,6 +15,7 @@ use Plack::Util::Accessor qw[
     expires
     secure
     httponly
+    samesite
 ];
 
 sub get_session_id {
@@ -31,6 +32,7 @@ sub merge_options {
     $options{domain}   = $self->domain      if !exists $options{domain} && defined $self->domain;
     $options{secure}   = $self->secure      if !exists $options{secure} && defined $self->secure;
     $options{httponly} = $self->httponly    if !exists $options{httponly} && defined $self->httponly;
+    $options{samesite} = $self->samesite    if !exists $options{samesite} && defined $self->samesite;
 
 
     if (!exists $options{expires} && defined $self->expires) {

--- a/t/015_cookie_options_mw.t
+++ b/t/015_cookie_options_mw.t
@@ -14,6 +14,7 @@ my $app = sub {
     $env->{'psgix.session.options'}{path}     = $path;
     $env->{'psgix.session.options'}{domain}   = '.example.com';
     $env->{'psgix.session.options'}{httponly} = 1;
+    $env->{'psgix.session.options'}{samesite} = 'Lax';
 
     return [ 200, [], [ "Hi" ] ];
 };
@@ -24,10 +25,10 @@ test_psgi $app, sub {
     my $cb = shift;
 
     my $res = $cb->(GET "http://localhost/");
-    like $res->header('Set-Cookie'), qr/plack_session=\w+; domain=.example.com; HttpOnly/;
+    like $res->header('Set-Cookie'), qr/plack_session=\w+; domain=.example.com; SameSite=Lax; HttpOnly/;
 
     $res = $cb->(GET "http://localhost/with_path");
-    like $res->header('Set-Cookie'), qr/plack_session=\w+; domain=.example.com; path=\/foo; HttpOnly/;
+    like $res->header('Set-Cookie'), qr/plack_session=\w+; domain=.example.com; path=\/foo; SameSite=Lax; HttpOnly/;
 };
 
 done_testing;


### PR DESCRIPTION
passes samesite config option thru to Cookie::Baker, which already supports it.