### PR TITLE
samesite test

### DIFF
--- a/lib/Plack/Middleware/Session/Cookie.pm
+++ b/lib/Plack/Middleware/Session/Cookie.pm
@@ -2,7 +2,7 @@ package Plack::Middleware::Session::Cookie;
 use strict;
 use parent qw(Plack::Middleware::Session);
 
-use Plack::Util::Accessor qw(secret session_key domain expires path secure httponly
+use Plack::Util::Accessor qw(secret session_key domain expires path secure httponly samesite
                              serializer deserializer);
 
 use Digest::HMAC_SHA1;
@@ -28,7 +28,7 @@ sub prepare_app {
       unless $self->deserializer;
 
     $self->state( Plack::Session::State::Cookie->new );
-    for my $attr (qw(session_key path domain expires secure httponly)) {
+    for my $attr (qw(session_key path domain expires secure httponly samesite)) {
         $self->state->$attr($self->$attr);
     }
 }

--- a/lib/Plack/Middleware/Session/Cookie.pm
+++ b/lib/Plack/Middleware/Session/Cookie.pm
@@ -141,7 +141,7 @@ middleware without setting a secret is vulnerable to arbitrary code
 execution. B<In the future release it will be required to set the
 secret>.
 
-=item session_key, domain, expires, path, secure, httponly
+=item session_key, domain, expires, path, secure, httponly, samesite
 
 Accessors for the cookie attributes. See
 L<Plack::Session::State::Cookie> for these options.

--- a/lib/Plack/Middleware/Session/Cookie.pm
+++ b/lib/Plack/Middleware/Session/Cookie.pm
@@ -2,8 +2,8 @@ package Plack::Middleware::Session::Cookie;
 use strict;
 use parent qw(Plack::Middleware::Session);
 
-use Plack::Util::Accessor qw(secret session_key domain expires path secure httponly samesite
-                             serializer deserializer);
+use Plack::Util::Accessor qw(secret session_key domain expires path secure httponly
+                             samesite serializer deserializer);
 
 use Digest::HMAC_SHA1;
 use MIME::Base64 ();

--- a/t/015_cookie_options_mw.t
+++ b/t/015_cookie_options_mw.t
@@ -1,6 +1,6 @@
 use strict;
 use Plack::Test;
-use Plack::Middleware::Session;
+use Plack::Middleware::Session::Cookie;
 use Test::More;
 use HTTP::Request::Common;
 use HTTP::Cookies;
@@ -13,22 +13,25 @@ my $app = sub {
     my $path = $env->{PATH_INFO} =~ /with_path/ ? "/foo" : undef;
     $env->{'psgix.session.options'}{path}     = $path;
     $env->{'psgix.session.options'}{domain}   = '.example.com';
-    $env->{'psgix.session.options'}{httponly} = 1;
-    $env->{'psgix.session.options'}{samesite} = 'Lax';
 
     return [ 200, [], [ "Hi" ] ];
 };
 
-$app = Plack::Middleware::Session->wrap($app);
+$app = Plack::Middleware::Session::Cookie->wrap(
+    $app,
+    secret   => 'foobar',
+    httponly => 1,
+    samesite => 'Lax',
+);
 
 test_psgi $app, sub {
     my $cb = shift;
 
     my $res = $cb->(GET "http://localhost/");
-    like $res->header('Set-Cookie'), qr/plack_session=\w+; domain=.example.com; SameSite=Lax; HttpOnly/;
+    like $res->header('Set-Cookie'), qr/plack_session=\S+; domain=.example.com; SameSite=Lax; HttpOnly/;
 
     $res = $cb->(GET "http://localhost/with_path");
-    like $res->header('Set-Cookie'), qr/plack_session=\w+; domain=.example.com; path=\/foo; SameSite=Lax; HttpOnly/;
+    like $res->header('Set-Cookie'), qr/plack_session=\S+; domain=.example.com; path=\/foo; SameSite=Lax; HttpOnly/;
 };
 
 done_testing;

--- a/t/015_cookie_options_mw.t
+++ b/t/015_cookie_options_mw.t
@@ -11,8 +11,8 @@ my $app = sub {
     $env->{'psgix.session'}->{counter} = 1;
 
     my $path = $env->{PATH_INFO} =~ /with_path/ ? "/foo" : undef;
-    $env->{'psgix.session.options'}{path}     = $path;
-    $env->{'psgix.session.options'}{domain}   = '.example.com';
+    $env->{'psgix.session.options'}{path}   = $path;
+    $env->{'psgix.session.options'}{domain} = '.example.com';
 
     return [ 200, [], [ "Hi" ] ];
 };


### PR DESCRIPTION
Support samesite cookie attribute via builder block, e.g. "enable 'Session::Cookie', samesite => 'Lax', ...".
Adds to earlier patches from gsteadwm and sparrow2009 with test and doc.