### PR TITLE
Add support for partitioned cookies

### DIFF
--- a/lib/Plack/Middleware/Session/Cookie.pm
+++ b/lib/Plack/Middleware/Session/Cookie.pm
@@ -3,7 +3,7 @@ use strict;
 use parent qw(Plack::Middleware::Session);
 
 use Plack::Util::Accessor qw(secret session_key domain expires path secure httponly
-                             samesite serializer deserializer);
+                             partitioned samesite serializer deserializer);
 
 use Digest::HMAC_SHA1;
 use MIME::Base64 ();
@@ -28,7 +28,7 @@ sub prepare_app {
       unless $self->deserializer;
 
     $self->state( Plack::Session::State::Cookie->new );
-    for my $attr (qw(session_key path domain expires secure httponly samesite)) {
+    for my $attr (qw(session_key path domain expires secure partitioned httponly samesite)) {
         $self->state->$attr($self->$attr);
     }
 }

--- a/t/014_cookie_options.t
+++ b/t/014_cookie_options.t
@@ -12,12 +12,21 @@ $st->expires(3600);
 $st->path('/cgi-bin');
 
 is_deeply +{ $st->merge_options(id => 123) },
-    { domain => '.example.com', secure => 1, expires => $time + 3600, path => '/cgi-bin' };
+  { domain => '.example.com', secure => 1, expires => $time + 3600, path => '/cgi-bin' };
 
 is_deeply +{ $st->merge_options(id => 123, path => '/', domain => '.perl.org') },
-    { domain => '.perl.org', secure => 1, expires => $time + 3600, path => '/' };
+  { domain => '.perl.org', secure => 1, expires => $time + 3600, path => '/' };
+
+is_deeply +{ $st->merge_options(id => 123, expires => $time + 1, secure => 0, partitioned => 0) },
+  { domain => '.example.com', secure => 0, expires => $time + 1, path => '/cgi-bin', partitioned => 0 };
+
+is_deeply +{ $st->merge_options(id => 123, expires => $time + 1, secure => 0, partitioned => 1) },
+  { domain => '.example.com', secure => 1, samesite => 'None', expires => $time + 1, path => '/cgi-bin', partitioned => 1 };
+
+$st->partitioned(1);
 
 is_deeply +{ $st->merge_options(id => 123, expires => $time + 1, secure => 0) },
-    { domain => '.example.com', secure => 0, expires => $time + 1, path => '/cgi-bin' };
+  { domain => '.example.com', secure => 1, samesite => 'None', expires => $time + 1, path => '/cgi-bin', partitioned => 1 };
+
 
 done_testing;


### PR DESCRIPTION
This adds support for partitioned cookies. This is already supported by `Cookie::Baker`, and the proposal/spec for them can be found here: https://developer.mozilla.org/en-US/docs/Web/Privacy/Privacy_sandbox/Partitioned_cookies

Thanks!