### PR TITLE
Use Crypt::SysRandom to generate the session_id

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -2,8 +2,9 @@ requires 'Plack'            => '0.9910';
 requires 'Cookie::Baker'    => '0.12';
 
 # for session ID gen
-requires 'Digest::SHA'       => '0';
+requires 'Crypt::SysRandom'  => '0';
 requires 'Digest::HMAC_SHA1' => '1.03';
+recommends 'Crypt::SysRandom::XS' => '0';
 
 # things the tests need
 on test => sub {
@@ -14,4 +15,3 @@ on test => sub {
     requires 'HTTP::Cookies';
     requires 'HTTP::Request::Common';
 };
-

--- a/lib/Plack/Session/State.pm
+++ b/lib/Plack/Session/State.pm
@@ -5,7 +5,9 @@ use warnings;
 our $VERSION   = '0.34';
 our $AUTHORITY = 'cpan:STEVAN';
 
-use Digest::SHA ();
+use Crypt::SysRandom ();
+
+# RECOMMEND PREREQ: Crypt::SysRandom::XS
 
 use Plack::Request;
 use Plack::Util::Accessor qw[
@@ -19,7 +21,7 @@ sub new {
 
     $params{'session_key'}   ||= 'plack_session';
     $params{'sid_generator'} ||= sub {
-        Digest::SHA::sha1_hex(rand() . $$ . {} . time)
+        unpack('H*', Crypt::SysRandom::random_bytes(20))
     };
     $params{'sid_validator'} ||= qr/\A[0-9a-f]{40}\Z/;
 


### PR DESCRIPTION
The hash uses low entropy and predicable data.  It makes more sense to retrieve raw random bytes from the system instead.

This improves the security, and if Crypt::SysRandom::XS is installed may also improve the speed.